### PR TITLE
Add option to select profile when installing theme

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,21 @@
-user=$(grep --max-count 1 'Path=' ~/.mozilla/firefox/profiles.ini | sed 's/Path=//g')
+#!/bin/bash
+echo "Available profiles:"
+
+profiles=($(grep 'Name=' ~/.mozilla/firefox/profiles.ini | sed 's/Name=//g'))
+
+for i in "${!profiles[@]}"; do
+    echo "$(($i + 1))=${profiles[$i]}"
+done
+
+echo "Specify which profile you want the theme to apply to (enter the number):" 
+read choice
+
+selected_profile=${profiles[$((choice - 1))]}
+
+echo "You selected: $selected_profile"
+user=$(grep --max-count 1 "Path=.*$selected_profile" ~/.mozilla/firefox/profiles.ini | sed 's/Path=//g')
+
+echo "Profile path: $user"
 
 userSettings=~/.mozilla/firefox/$user/user.js
 userChromeCSSPath=~/.mozilla/firefox/$user/chrome/userChrome.css
@@ -13,3 +30,4 @@ if [ ! -e "$userSettings" ] || (! grep 'toolkit.legacyUserProfileCustomizations.
 fi
 
 echo "userChrome.css installed!"
+


### PR DESCRIPTION
Hello,
I find your theme very cool!
However, when I tried to install the theme, it turned out that it installed it to the default profile.

So, I modified the script to allow the user to choose which profile to install the theme to. This seems to be working correctly, and now the user can select the desired profile.
![image](https://github.com/user-attachments/assets/2c6b512a-463e-4ee1-88cc-62a592d5458c)
